### PR TITLE
update: move examples to examples dir, update cargo docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,27 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "=1.0"
 thiserror = "1.0.58"
+
+[[example]]
+name = "get_voices"
+path = "examples/get_voices/main.rs"
+
+[[example]]
+name = "clone_voices"
+path = "examples/clone_voices/main.rs"
+
+[[example]]
+name = "tts_jobs"
+path = "examples/tts_jobs/main.rs"
+
+[[example]]
+name = "tts_job_progress"
+path = "examples/tts_job_progress/main.rs"
+
+[[example]]
+name = "tts_job_audio_stream"
+path = "examples/tts_job_audio_stream/main.rs"
+
+[[example]]
+name = "tts_audio_stream"
+path = "examples/tts_audio_stream/main.rs"

--- a/examples/clone_voices/main.rs
+++ b/examples/clone_voices/main.rs
@@ -1,3 +1,4 @@
+//! `cargo run --example clone_voices -- "/path/to/voice.m4a" "audio/x-m4a"`
 use playht_rs::{
     api::{self, voice::CloneVoiceFileRequest, voice::DeleteClonedVoiceRequest},
     prelude::*,

--- a/examples/get_voices/main.rs
+++ b/examples/get_voices/main.rs
@@ -1,3 +1,4 @@
+//! `cargo run --example get_voices`
 use playht_rs::{
     api::{self, voice::get_stock_voices},
     prelude::*,

--- a/examples/tts_audio_stream/main.rs
+++ b/examples/tts_audio_stream/main.rs
@@ -1,3 +1,4 @@
+//! `cargo run --example tts_audio_stream -- "foobar.mp3"`
 use playht_rs::{
     api::{self, stream::TTSStreamReq, tts::Quality},
     prelude::*,

--- a/examples/tts_job_audio_stream/main.rs
+++ b/examples/tts_job_audio_stream/main.rs
@@ -1,3 +1,4 @@
+//! `cargo run --example tts_job_audio_stream -- "job-id" "/path/to/output.mp3"`
 use playht_rs::{api, api::job, prelude::*};
 use tokio::{fs::File, io::BufWriter};
 

--- a/examples/tts_job_progress/main.rs
+++ b/examples/tts_job_progress/main.rs
@@ -1,3 +1,4 @@
+//! `cargo run --example tts_job_progress`
 use playht_rs::{
     api::{self, job::TTSJobReq, tts::Quality},
     prelude::*,

--- a/examples/tts_jobs/main.rs
+++ b/examples/tts_jobs/main.rs
@@ -1,3 +1,4 @@
+//! `cargo run --example tts_jobs`
 use playht_rs::{
     api::{self, job::TTSJobReq, tts::Quality},
     prelude::*,

--- a/src/api/job.rs
+++ b/src/api/job.rs
@@ -1,3 +1,8 @@
+//! module for managing and monitoring the play.ht async TTS jobs.
+//!
+//! It lets you create, fetch, delete and monitor the progress
+//! of the async TTS jobs.
+
 use crate::{
     api::tts::{Emotion, OutputFormat, Quality, VoiceEngine},
     api::Client,
@@ -5,8 +10,10 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
+/// URL path for creating and fetching async TTS jobs.
 pub const TTS_JOB_PATH: &str = "/tts";
 
+/// Used to request creating of async TTS jobs.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct TTSJobReq {
@@ -55,6 +62,7 @@ impl Default for TTSJobReq {
     }
 }
 
+/// TTS job output metadata.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Output {
     pub duration: f64,
@@ -62,6 +70,7 @@ pub struct Output {
     pub url: String,
 }
 
+/// A TTS job progress metadata.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Link {
     #[serde(rename = "contentType")]
@@ -72,6 +81,7 @@ pub struct Link {
     pub rel: Option<String>,
 }
 
+/// TTS job metadata.
 #[derive(Debug, Clone, Deserialize)]
 pub struct TTSJob {
     pub id: String,
@@ -84,15 +94,17 @@ pub struct TTSJob {
     pub links: Option<Vec<Link>>,
 }
 
-/// Create a new TTS job.
+/// Creates a new TTS job.
+/// Convenience method which does the same thing as [`crate::api::Client::create_tts_job`].
 pub async fn create_tts_job(req: TTSJobReq) -> Result<TTSJob> {
     let tts_job = Client::new().create_tts_job(req).await?;
 
     Ok(tts_job)
 }
 
-/// Create a new TTS job and immediately stream its progress into w.
-/// The job progress stream URL is returned if it gets created.
+/// Creates a new TTS job and immediately streams its progress.
+/// The job progress stream URL is returned if the job gets successfully created.
+/// Convenience method which does the same thing as [`crate::api::Client::create_tts_job_with_progress_stream`].
 pub async fn create_tts_job_with_progress_stream<W>(
     w: &mut W,
     req: TTSJobReq,
@@ -107,14 +119,16 @@ where
     Ok(stream_url)
 }
 
-/// Get the TTS job with the given id.
+/// Fetches a TTS job with the given id.
+/// Convenience method which does the same thing as [`crate::api::Client::get_tts_job`].
 pub async fn get_tts_job(id: String) -> Result<TTSJob> {
     let tts_job = Client::new().get_tts_job(id).await?;
 
     Ok(tts_job)
 }
 
-/// Stream the progress of the TTS job with the given id into w.
+/// Streams the progress of a TTS job with the given id.
+/// Convenience method which does the same thing as [`crate::api::Client::stream_tts_job_progress`].
 pub async fn stream_tts_job_progress<W>(w: &mut W, id: String) -> Result<()>
 where
     W: tokio::io::AsyncWriteExt + Unpin,
@@ -124,7 +138,8 @@ where
     Ok(())
 }
 
-/// Stream audio for the TTS job with the given id into w.
+/// Streams audio data for the TTS job with the given id.
+/// Convenience method which does the same thing as [`crate::api::Client::stream_tts_job_audio`].
 pub async fn stream_tts_job_audio<W>(w: &mut W, id: String) -> Result<()>
 where
     W: tokio::io::AsyncWriteExt + Unpin,

--- a/src/api/job.rs
+++ b/src/api/job.rs
@@ -1,6 +1,6 @@
-//! module for managing and monitoring the play.ht async TTS jobs.
+//! module for managing and monitoring async TTS jobs.
 //!
-//! It lets you create, fetch, delete and monitor the progress
+//! You can create, fetch, delete and monitor the progress
 //! of the async TTS jobs.
 
 use crate::{
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 /// URL path for creating and fetching async TTS jobs.
 pub const TTS_JOB_PATH: &str = "/tts";
 
-/// Used to request creating of async TTS jobs.
+/// TTS jobs creation request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct TTSJobReq {
@@ -70,7 +70,7 @@ pub struct Output {
     pub url: String,
 }
 
-/// A TTS job progress metadata.
+/// TTS job progress metadata.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Link {
     #[serde(rename = "contentType")]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -19,16 +19,21 @@ use voice::{
     DeleteClonedVoiceResp, Voice, CLONED_VOICES_INSTANT_PATH, CLONED_VOICES_PATH, VOICES_PATH,
 };
 
-const BASE_URL: &str = "https://api.play.ht/api";
+/// Base URL path.
+pub const BASE_URL: &str = "https://api.play.ht/api";
+/// V2 URL path.
 const V2_PATH: &str = "/v2";
 // TODO: this is used for gRPC streaming
 // Remove this attribute once implemented.
 #[allow(unused)]
 const V1_PATH: &str = "/v1";
 
-const USER_ID_HEADER: &str = "X-USER-ID";
-const CLIENT_USER_AGENT: &str = "milosgajdos/playht_rs";
+/// HTTP header used for API authentication.
+pub const USER_ID_HEADER: &str = "X-USER-ID";
+/// API client `User-Agent` used in the HTTP requests.
+pub const CLIENT_USER_AGENT: &str = "milosgajdos/playht_rs";
 
+/// Provides <https://play.ht> API client implementation.
 #[derive(Debug)]
 pub struct Client {
     client: reqwest::Client,
@@ -36,7 +41,11 @@ pub struct Client {
     pub headers: HeaderMap,
 }
 
+/// Provides <https://play.ht> API client implementation.
 impl Client {
+    /// Create a new client and return it.
+    /// It automatically initializes the client URL
+    /// to the [play.ht](https://play.ht) API [`BASE_URL`].
     pub fn new() -> Self {
         // NOTE: unwrap is warranted because default()
         // only sets up default configuration which
@@ -46,6 +55,8 @@ impl Client {
         c
     }
 
+    /// Return the remote host address as a string.
+    /// The returned address has the following format: `host:port`.
     pub fn remote_address(&self) -> String {
         let host = self.url.host().unwrap();
         let addr = format!("{}:{}", host, "443");
@@ -53,6 +64,12 @@ impl Client {
         addr
     }
 
+    /// Build a request with a given `Method` and `body`.
+    /// The reeturned request can then be passed to [`Client::send_request`].
+    /// Generally, we recommend using one of the [`Client`] methods
+    /// which builds the request for you automatically, but sometimes
+    /// this might come in handy, such as when a new API endpoint
+    /// is added and you don't want to wait for it to be added to this crate.
     pub fn build_request<T: Into<Body>>(&self, method: Method, body: T) -> Result<Request> {
         let mut req_builder = self.client.request(method, self.url.clone());
         for (name, value) in &self.headers {
@@ -63,12 +80,17 @@ impl Client {
         Ok(req)
     }
 
+    /// Send the request to the remote API.
+    /// We recommend using one of the specific [`Client`] methods,
+    /// but as with [`Client::build_request`], this can be handy in some situations.
     pub async fn send_request(&self, req: Request) -> Result<Response> {
         let resp = self.client.execute(req).await?;
 
         Ok(resp)
     }
 
+    /// Returns all available stock voices.
+    /// See the [official docs](https://docs.play.ht/reference/api-list-ultra-realistic-voices).
     pub async fn get_stock_voices(&self) -> Result<Vec<Voice>> {
         let voices_url = format!("{}{}", self.url.as_str(), VOICES_PATH);
         let resp = self
@@ -88,6 +110,8 @@ impl Client {
         Err(Box::new(Error::APIError(api_error)))
     }
 
+    /// Returns all cloned voices.
+    /// See the [official docs](https://docs.play.ht/reference/api-list-cloned-voices);
     pub async fn get_cloned_voices(&self) -> Result<Vec<ClonedVoice>> {
         let voices_url = format!("{}{}", self.url.as_str(), CLONED_VOICES_PATH);
         let resp = self
@@ -107,6 +131,8 @@ impl Client {
         Err(Box::new(Error::APIError(api_error)))
     }
 
+    /// Clone a voice clone from a file specified in the [`request`][voice::CloneVoiceFileRequest].
+    /// Seee the [official docs](https://docs.play.ht/reference/api-create-instant-voice-clone).
     pub async fn clone_voice_from_file(&self, req: CloneVoiceFileRequest) -> Result<ClonedVoice> {
         let voice_name_part = multipart::Part::text(req.voice_name).mime_str(TEXT_PLAIN)?;
         let sample_file_part = multipart::Part::bytes(std::fs::read(&req.sample_file)?)
@@ -140,6 +166,8 @@ impl Client {
         Err(Box::new(Error::APIError(api_error)))
     }
 
+    /// Create a voice clone from a URL specified in the [`request`][voice::CloneVoiceURLRequest].
+    /// See the [official docs](https://docs.play.ht/reference/api-create-instant-voice-clone-via-file-url).
     pub async fn clone_voice_from_url(&self, req: CloneVoiceURLRequest) -> Result<ClonedVoice> {
         let body = serde_json::to_string(&req)?;
         let clone_voice_url = format!("{}{}", self.url.as_str(), CLONED_VOICES_PATH);
@@ -161,6 +189,8 @@ impl Client {
         Err(Box::new(Error::APIError(api_error)))
     }
 
+    /// Delete a cloned voice.
+    /// See the [official docs](https://docs.play.ht/reference/api-delete-cloned-voices).
     pub async fn delete_cloned_voice(
         &self,
         req: DeleteClonedVoiceRequest,
@@ -186,6 +216,8 @@ impl Client {
         Err(Box::new(Error::APIError(api_error)))
     }
 
+    /// Create an async TTS job and return its metadata.
+    /// See the [official docs](https://docs.play.ht/reference/api-generate-audio).
     pub async fn create_tts_job(&self, req: TTSJobReq) -> Result<TTSJob> {
         let body = serde_json::to_string(&req)?;
         let tts_job_url = format!("{}{}", self.url.as_str(), TTS_JOB_PATH);
@@ -208,6 +240,10 @@ impl Client {
         Err(Box::new(Error::APIError(api_error)))
     }
 
+    /// Create an async TTS job and immediately stream the progres into the given writer.
+    /// See the [official docs](https://docs.play.ht/reference/api-generate-audio).
+    /// NOTE: The stream written into the given writer contains SSE events
+    /// reporting the progress of the async job.
     pub async fn create_tts_job_with_progress_stream<W>(
         &self,
         w: &mut W,
@@ -240,6 +276,8 @@ impl Client {
         Ok(stream_url)
     }
 
+    /// Query the async TTS job and return it.
+    /// See the [official docs](https://docs.play.ht/reference/api-get-tts-data).
     pub async fn get_tts_job(&self, id: String) -> Result<TTSJob> {
         let tts_job_url = format!("{}{}/{}", self.url.as_str(), TTS_JOB_PATH, id);
         let resp = self
@@ -259,6 +297,10 @@ impl Client {
         Err(Box::new(Error::APIError(api_error)))
     }
 
+    /// Stream the progress of the TTS job with the given id.
+    /// Unlike [`Client::create_tts_job_with_progress_stream`] this doe NOT
+    /// create a new TTS job, but merely streams the SSE events about its progress.
+    /// See the [official docs](https://docs.play.ht/reference/api-get-tts-data).
     pub async fn stream_tts_job_progress<W>(&self, w: &mut W, id: String) -> Result<()>
     where
         W: tokio::io::AsyncWriteExt + Unpin,
@@ -279,6 +321,11 @@ impl Client {
         Ok(())
     }
 
+    /// Stream the audio from the TTS job in real time.
+    /// Unlike [`Client::stream_tts_job_progress`] this does not stream the SSE events
+    /// reporting the progress of the async job that had been create, but rather
+    /// it automatically streams the raw audio data to the given writer.
+    /// See the [official docs](https://docs.play.ht/reference/api-get-tts-data).
     pub async fn stream_tts_job_audio<W>(&self, w: &mut W, id: String) -> Result<()>
     where
         W: tokio::io::AsyncWriteExt + Unpin,
@@ -299,6 +346,10 @@ impl Client {
         Ok(())
     }
 
+    /// Stream TTS audio in real-time to the given writer.
+    /// Unlike [`Client::stream_tts_job_audio`] this does not create an async job.
+    /// Instead it immediately starts streaming the audio data into the given writer.
+    /// See the [official docs](https://docs.play.ht/reference/api-generate-tts-audio-stream).
     pub async fn stream_audio<W>(&self, w: &mut W, req: TTSStreamReq) -> Result<()>
     where
         W: tokio::io::AsyncWriteExt + Unpin,
@@ -323,6 +374,9 @@ impl Client {
         Ok(())
     }
 
+    /// Get the audio stream URL instead of streaming the raw audio like [`Client::stream_audio`].
+    /// You can then use the returned URL for fetching the stream.
+    /// See the [official docs](https://docs.play.ht/reference/api-generate-tts-audio-stream).
     pub async fn get_audio_stream_url(&self, req: TTSStreamReq) -> Result<TTSStreamURL> {
         let body = serde_json::to_string(&req)?;
         let tts_stream_url = format!("{}{}", self.url.as_str(), TTS_STREAM_PATH);
@@ -347,6 +401,7 @@ impl Client {
     }
 }
 
+/// Used to configure the API [`Client`].
 #[derive(Debug)]
 pub struct ClientBuilder {
     client: Option<reqwest::Client>,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,3 +1,10 @@
+//! Provides an implementation of play.ht API client.
+//!
+//! Use the [`Client`] for interacing with playht API.
+//! You can configure various aspects of the [`Client`] with [`ClientBuilder`].
+//! Note that the client is async. It leverages [`tokio`] runtime.
+//!
+
 pub mod job;
 pub mod stream;
 pub mod tts;
@@ -19,21 +26,22 @@ use voice::{
     DeleteClonedVoiceResp, Voice, CLONED_VOICES_INSTANT_PATH, CLONED_VOICES_PATH, VOICES_PATH,
 };
 
-/// Base URL path.
+/// API Base URL.
 pub const BASE_URL: &str = "https://api.play.ht/api";
-/// V2 URL path.
+/// V2 API URL path.
 const V2_PATH: &str = "/v2";
 // TODO: this is used for gRPC streaming
 // Remove this attribute once implemented.
 #[allow(unused)]
+/// V1 API URL path.
 const V1_PATH: &str = "/v1";
 
 /// HTTP header used for API authentication.
 pub const USER_ID_HEADER: &str = "X-USER-ID";
-/// API client `User-Agent` used in the HTTP requests.
+/// API client `User-Agent`.
 pub const CLIENT_USER_AGENT: &str = "milosgajdos/playht_rs";
 
-/// Provides <https://play.ht> API client implementation.
+/// <https://play.ht> API client.
 #[derive(Debug)]
 pub struct Client {
     client: reqwest::Client,
@@ -401,7 +409,7 @@ impl Client {
     }
 }
 
-/// Used to configure the API [`Client`].
+/// Configures and builds the [`Client`].
 #[derive(Debug)]
 pub struct ClientBuilder {
     client: Option<reqwest::Client>,

--- a/src/api/stream.rs
+++ b/src/api/stream.rs
@@ -1,3 +1,7 @@
+//! module for streaming TTS audio in real-time.
+//!
+//! It lets you create and stream the audio in real-time.
+
 use crate::{
     api::tts::{Emotion, OutputFormat, Quality, VoiceEngine},
     api::Client,
@@ -5,8 +9,10 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
+/// URL path for fetching the audio streams.
 pub const TTS_STREAM_PATH: &str = "/tts/stream";
 
+/// Audio stream request options.
 #[derive(Debug, Clone, Serialize)]
 #[serde(default)]
 pub struct TTSStreamReq {
@@ -45,6 +51,7 @@ impl Default for TTSStreamReq {
     }
 }
 
+/// Audio stream URL metadata.
 #[derive(Debug, Clone, Deserialize)]
 pub struct TTSStreamURL {
     pub href: String,
@@ -55,7 +62,8 @@ pub struct TTSStreamURL {
     pub description: String,
 }
 
-/// Stream audio for the given input request into w.
+/// Stream raw audio data.
+/// This is a convenience function that does the same thing as [`crate::api::Client::stream_audio`].
 pub async fn stream_audio<W>(w: &mut W, req: TTSStreamReq) -> Result<()>
 where
     W: tokio::io::AsyncWriteExt + Unpin,
@@ -65,7 +73,8 @@ where
     Ok(())
 }
 
-/// Get audio stream URL for the given input request.
+/// Fetch the URL for audio stream.
+/// This is a convenience function that does the same thing as [`crate::api::Client::get_audio_stream_url`].
 pub async fn get_audio_stream_url(req: TTSStreamReq) -> Result<TTSStreamURL> {
     let audio_stream_url = Client::new().get_audio_stream_url(req).await?;
 

--- a/src/api/stream.rs
+++ b/src/api/stream.rs
@@ -1,6 +1,6 @@
 //! module for streaming TTS audio in real-time.
 //!
-//! It lets you create and stream the audio in real-time.
+//! You can create new audio streams and stream them in real-time.
 
 use crate::{
     api::tts::{Emotion, OutputFormat, Quality, VoiceEngine},

--- a/src/api/tts.rs
+++ b/src/api/tts.rs
@@ -1,5 +1,11 @@
+//! module that defines various TTS data structures throughout API.
+
 use serde::{Deserialize, Serialize};
 
+/// play.ht voice engine.
+/// It's recommended you use the [`v2`][v2] engine.
+///
+/// [v2]: VoiceEngine::PlayHTV2
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub enum VoiceEngine {
     #[serde(rename = "PlayHT1.0")]
@@ -11,6 +17,10 @@ pub enum VoiceEngine {
     PlayHTV2Turbo,
 }
 
+/// Supported audio output formats.
+/// By default [`mp3`][m] is used.
+///
+/// [m]: OutputFormat::Mp3
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum OutputFormat {
@@ -22,6 +32,10 @@ pub enum OutputFormat {
     Mulav,
 }
 
+/// Quality of the generated audio stream.
+/// By default [`draft`][d] is used.
+///
+/// [d]: Quality::Draft
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum Quality {
@@ -33,6 +47,10 @@ pub enum Quality {
     Premium,
 }
 
+/// Emotion in the generated TTS voice.
+/// By default [`FemaleHappy`][fh] is used.
+///
+/// [fh]: Emotion::FemaleHappy
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum Emotion {

--- a/src/api/tts.rs
+++ b/src/api/tts.rs
@@ -1,4 +1,7 @@
-//! module that defines various TTS data structures throughout API.
+//! module that defines various TTS data structures.
+//!
+//! These data structures are used for configuring
+//! various properties of TTS streams and jobs.
 
 use serde::{Deserialize, Serialize};
 

--- a/src/api/voice.rs
+++ b/src/api/voice.rs
@@ -1,4 +1,4 @@
-//! module for cloning voices from files or URLs.
+//! module for cloning and fetching voices from files or URLs.
 //!
 //! It lets you create, fetch delete cloned voices.
 

--- a/src/api/voice.rs
+++ b/src/api/voice.rs
@@ -1,10 +1,18 @@
+//! module for cloning voices from files or URLs.
+//!
+//! It lets you create, fetch delete cloned voices.
+
 use crate::{api::Client, prelude::*};
 use serde::{Deserialize, Serialize};
 
+/// URL path for fetching stock voices.
 pub const VOICES_PATH: &str = "/voices";
+/// URL path for fetching cloned voices.
 pub const CLONED_VOICES_PATH: &str = "/cloned-voices/";
+/// URL path for creating cloned voices.
 pub const CLONED_VOICES_INSTANT_PATH: &str = "/cloned-voices/instant";
 
+/// Voice metadata
 #[derive(Debug, Deserialize, Clone)]
 pub struct Voice {
     pub id: String,
@@ -21,6 +29,7 @@ pub struct Voice {
     pub texture: Option<String>,
 }
 
+/// Cloned voice metadata.
 #[derive(Debug, Deserialize, Clone)]
 pub struct ClonedVoice {
     pub id: String,
@@ -28,6 +37,7 @@ pub struct ClonedVoice {
     pub r#type: Option<String>,
 }
 
+/// Voice cloning request.
 #[derive(Debug, Clone)]
 pub struct CloneVoiceFileRequest {
     pub sample_file: String,
@@ -35,45 +45,52 @@ pub struct CloneVoiceFileRequest {
     pub mime_type: String,
 }
 
+/// Voice clone URL request.
 #[derive(Debug, Serialize, Clone)]
 pub struct CloneVoiceURLRequest {
     pub sample_file_url: String,
     pub voice_name: String,
 }
 
+/// Voice clone delete request.
 #[derive(Debug, Serialize, Clone)]
 pub struct DeleteClonedVoiceRequest {
     pub voice_id: String,
 }
 
+/// Voice clone success response.
 #[derive(Debug, Deserialize, Clone)]
 pub struct DeleteClonedVoiceResp {
     pub message: String,
     pub deleted: ClonedVoice,
 }
 
-/// Get all available stock Voices.
+/// Get all available stock voices.
+/// Convenience function that does the same thing as [`crate::api::Client::get_stock_voices`].
 pub async fn get_stock_voices() -> Result<Vec<Voice>> {
     let voices = Client::new().get_stock_voices().await?;
 
     Ok(voices)
 }
 
-/// Get all cloned Voices.
+/// Get all cloned voices.
+/// Convenience function that does the same thing as [`crate::api::Client::get_cloned_voices`].
 pub async fn get_cloned_voices() -> Result<Vec<ClonedVoice>> {
     let voices = Client::new().get_cloned_voices().await?;
 
     Ok(voices)
 }
 
-/// Clone voice from the file specified via req.
+/// Clone voice from the give file.
+/// Convenience function that does the same thing as [`crate::api::Client::clone_voice_from_file`].
 pub async fn clone_voice_from_file(req: CloneVoiceFileRequest) -> Result<ClonedVoice> {
     let voice = Client::new().clone_voice_from_file(req).await?;
 
     Ok(voice)
 }
 
-/// Clone voice from the URL specified via req.
+/// Clone voice from the given URL.
+/// Convenience function that does the same thing as [`crate::api::Client::clone_voice_from_url`].
 pub async fn clone_voice_from_url(req: CloneVoiceURLRequest) -> Result<ClonedVoice> {
     let voice = Client::new().clone_voice_from_url(req).await?;
 
@@ -81,6 +98,7 @@ pub async fn clone_voice_from_url(req: CloneVoiceURLRequest) -> Result<ClonedVoi
 }
 
 /// Delete cloned voice.
+/// Convenience function that does the same thing as [`crate::api::Client::delete_cloned_voice`].
 pub async fn delete_cloned_voice(req: DeleteClonedVoiceRequest) -> Result<DeleteClonedVoiceResp> {
     let delete_resp = Client::new().delete_cloned_voice(req).await?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,11 @@
+//! Defines errors used in the crate.
+//!
+
 use serde::{self, Deserialize, Deserializer};
 use thiserror;
 
+/// Error defines the types of error that can be
+/// returned from any of the crate module functions.
 #[derive(Debug, thiserror::Error, Deserialize)]
 pub enum Error {
     #[error("Client build error: {0}")]
@@ -9,6 +14,16 @@ pub enum Error {
     APIError(APIError),
 }
 
+/// Deserialized API Errors as returned by play.ht API.
+///
+/// play.ht returns 3 different types of errors
+/// * [`Gen`][g] - a generic JSON serialized error with strict schema.
+/// * [`Internal`][i] - a JSON serialized error returned when 50x status codes.
+/// * [`RateLimit`][r] - a simple string informing you you've hit rate limit quota.
+///
+/// [g]: APIError::Gen
+/// [i]: APIError::Internal
+/// [r]: APIError::RateLimit
 #[derive(Debug, thiserror::Error)]
 pub enum APIError {
     #[error("Generic API error: {error_message} ({error_id})")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@
 //!
 //! An unofficial play.ht API client library.
 //!
-//! play.ht homesite: https://play.ht/
+//! play.ht homesite: <https://play.ht/>
 //!
-//! play.ht API docs: https://docs.play.ht/reference/api-getting-started
+//! play.ht API docs: <https://docs.play.ht/reference/api-getting-started>
 //!
 
 pub use crate::api::{

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,15 @@
+//! Prelude defines various constants and type aliases.
+
+/// Result type alias used in this crate.
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
+/// `application/json` HTTP header
 pub const APPLICATION_JSON: &str = "application/json";
+/// `multipart/form-data` HTTP header
 pub const MULTIPART_FORM: &str = "multipart/form-data";
+/// `text/plain` HTTP header
 pub const TEXT_PLAIN: &str = "text/plain";
+/// `text/event-stream` HTTP header
 pub const TEXT_EVENT_STREAM: &str = "text/event-stream";
+/// `audio/mpeg` HTTP header
 pub const AUDIO_MPEG: &str = "audio/mpeg";


### PR DESCRIPTION
We've moved the original code samples from standalone programs to the preferred cargo examples directory.

We've made a major cargo docs update documenting all the modules APIs.