### PR TITLE
ci: build all targets so examples are built

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,11 +38,11 @@ jobs:
 
       - name: run build
         run: |
-          cargo check --verbose
-          cargo build --release --verbose
+          cargo check --all-targets --verbose
+          cargo build --all-targets --release --verbose
 
       - name: run tests
-        run: cargo test --verbose
+        run: cargo test --all-targets --verbose
 
       - name: publish crate
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Unless you explicitly specify `--all-targets`, `cargo` won't build the examples. Sadness.

This PR updates the GHA that does it.