### PR TITLE
feat: retun a stream object from stream_audio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.12", features = ["json", "multipart"] }
+reqwest = { version = "0.12", features = ["json", "multipart", "stream"] }
 tokio = { version = "1", features = ["full"] }
+tokio-stream = { version = "0.1" }
+bytes = { version = "1", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "=1.0"
 thiserror = "1.0.58"
@@ -31,6 +33,10 @@ name = "clone_voices"
 path = "examples/clone_voices/main.rs"
 
 [[example]]
+name = "play_audio"
+path = "examples/play_audio/main.rs"
+
+[[example]]
 name = "tts_jobs"
 path = "examples/tts_jobs/main.rs"
 
@@ -43,5 +49,13 @@ name = "tts_job_audio_stream"
 path = "examples/tts_job_audio_stream/main.rs"
 
 [[example]]
-name = "tts_audio_stream"
-path = "examples/tts_audio_stream/main.rs"
+name = "tts_play_audio_stream"
+path = "examples/tts_play_audio_stream/main.rs"
+
+[[example]]
+name = "tts_write_audio_stream"
+path = "examples/tts_write_audio_stream/main.rs"
+
+[[example]]
+name = "tts_stream_audio"
+path = "examples/tts_stream_audio/main.rs"

--- a/examples/tts_play_audio_stream/main.rs
+++ b/examples/tts_play_audio_stream/main.rs
@@ -1,4 +1,4 @@
-//! `cargo run --example play_tts_audio_stream`
+//! `cargo run --example tts_play_audio_stream`
 use playht_rs::{
     api::{self, stream::TTSStreamReq, tts::Quality},
     prelude::*,
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
     let sink = Sink::try_new(&stream_handle).unwrap();
 
     let mut buffer = Vec::new();
-    client.stream_audio(&mut buffer, req).await?;
+    client.write_audio_stream(&mut buffer, req).await?;
 
     let source = Decoder::new(Cursor::new(buffer)).unwrap();
     sink.append(source);

--- a/examples/tts_stream_audio/main.rs
+++ b/examples/tts_stream_audio/main.rs
@@ -1,0 +1,70 @@
+//! ` cargo run --example tts_stream_audio`
+use bytes::BytesMut;
+use playht_rs::{
+    api::{self, stream::TTSStreamReq, tts::Quality},
+    prelude::*,
+};
+use rodio::{Decoder, OutputStream, Sink};
+use std::io::Cursor;
+use tokio_stream::StreamExt;
+
+// NOTE: this might need to be adjusted
+const BUFFER_SIZE: usize = 1024 * 10;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = api::Client::new();
+    let voices = client.get_stock_voices().await?;
+    if voices.is_empty() {
+        return Err("No voices available for playback".into());
+    }
+    let client = api::Client::new();
+    let req = TTSStreamReq {
+        text: Some("What is life?".to_owned()),
+        voice: Some(voices[0].id.to_owned()),
+        quality: Some(Quality::Low),
+        speed: Some(1.0),
+        sample_rate: Some(24000),
+        ..Default::default()
+    };
+
+    let (_stream, stream_handle) = OutputStream::try_default().unwrap();
+    let sink = Sink::try_new(&stream_handle).unwrap();
+
+    let mut stream = client.stream_audio(req).await?;
+    let mut accumulated = BytesMut::new();
+
+    while let Some(res) = stream.next().await {
+        match res {
+            Ok(chunk) => {
+                accumulated.extend_from_slice(&chunk);
+                // Check if there's enough data to attempt decoding
+                if accumulated.len() > BUFFER_SIZE {
+                    let cursor = Cursor::new(accumulated.clone().freeze().to_vec());
+                    match Decoder::new(cursor) {
+                        Ok(source) => {
+                            sink.append(source);
+                            accumulated.clear(); // Clear the buffer on successful append
+                        }
+                        Err(e) => {
+                            eprintln!("Failed to decode received audio: {}", e);
+                        }
+                    }
+                }
+            }
+            Err(err) => return Err(format!("Playback error: {}", err).into()),
+        }
+    }
+
+    // Flush any remaining data at the end
+    if !accumulated.is_empty() {
+        let cursor = Cursor::new(accumulated.to_vec());
+        match Decoder::new(cursor) {
+            Ok(source) => sink.append(source),
+            Err(e) => println!("Remaining data could not be decoded: {}", e),
+        }
+    }
+
+    sink.sleep_until_end();
+    Ok(())
+}

--- a/examples/tts_write_audio_stream/main.rs
+++ b/examples/tts_write_audio_stream/main.rs
@@ -1,4 +1,4 @@
-//! `cargo run --example tts_audio_stream -- "foobar.mp3"`
+//! `cargo run --example tts_write_audio_stream -- "foobar.mp3"`
 use playht_rs::{
     api::{self, stream::TTSStreamReq, tts::Quality},
     prelude::*,
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
     };
     let file = File::create(file_path.clone()).await?;
     let mut w = BufWriter::new(file);
-    client.stream_audio(&mut w, req).await?;
+    client.write_audio_stream(&mut w, req).await?;
     println!("Done streaming into {}", file_path);
 
     Ok(())

--- a/src/api/stream.rs
+++ b/src/api/stream.rs
@@ -7,7 +7,9 @@ use crate::{
     api::Client,
     prelude::*,
 };
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
+use tokio_stream::Stream;
 
 /// URL path for fetching the audio streams.
 pub const TTS_STREAM_PATH: &str = "/tts/stream";
@@ -62,13 +64,13 @@ pub struct TTSStreamURL {
     pub description: String,
 }
 
-/// Stream raw audio data.
-/// This is a convenience function that does the same thing as [`crate::api::Client::stream_audio`].
-pub async fn stream_audio<W>(w: &mut W, req: TTSStreamReq) -> Result<()>
+/// Stream raw TTS audio into the given writer.
+/// This is a convenience function that does the same thing as [`crate::api::Client::write_audio_stream`].
+pub async fn write_audio_stream<W>(w: &mut W, req: TTSStreamReq) -> Result<()>
 where
     W: tokio::io::AsyncWriteExt + Unpin,
 {
-    Client::new().stream_audio(w, req).await?;
+    Client::new().write_audio_stream(w, req).await?;
 
     Ok(())
 }
@@ -79,4 +81,12 @@ pub async fn get_audio_stream_url(req: TTSStreamReq) -> Result<TTSStreamURL> {
     let audio_stream_url = Client::new().get_audio_stream_url(req).await?;
 
     Ok(audio_stream_url)
+}
+
+/// Stream TTS audio using the returned stream.
+/// This is a convenience function that does the same thing as [`crate::api::Client::stream_audio`].
+pub async fn stream_audio(req: TTSStreamReq) -> Result<impl Stream<Item = StreamResult<Bytes>>> {
+    let audio_stream = Client::new().stream_audio(req).await?;
+
+    Ok(audio_stream)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub use crate::api::{
         create_tts_job, create_tts_job_with_progress_stream, get_tts_job, stream_tts_job_audio,
         stream_tts_job_progress,
     },
-    stream::{get_audio_stream_url, stream_audio},
+    stream::{get_audio_stream_url, stream_audio, write_audio_stream},
     voice::{
         clone_voice_from_file, clone_voice_from_url, delete_cloned_voice, get_cloned_voices,
         get_stock_voices,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,11 @@
 //! Prelude defines various constants and type aliases.
 
+use reqwest;
+
 /// Result type alias used in this crate.
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+pub type StreamResult<T> = std::result::Result<T, reqwest::Error>;
 
 /// `application/json` HTTP header
 pub const APPLICATION_JSON: &str = "application/json";


### PR DESCRIPTION
Previously you had to supply an async buffer to "stream" audio, but that proved to be challenging when attempting to play the audio in real time. We have now added a stream_audio method that returns a stream and renamed the original method to write_audio_stream so it's clearer what it actually does.

We've done a serious cleanup of README and examples and made sure all the examples are compiled during CI runs.